### PR TITLE
Fix command line options when extract archive

### DIFF
--- a/src/tar.c
+++ b/src/tar.c
@@ -267,7 +267,7 @@ gboolean xa_tar_extract (XArchive *archive, GSList *file_list)
 	                      " -x --no-recursion --no-wildcards",
 	                      " -f ", archive->path[2],
 	                      archive->do_touch ? " -m" : "",
-	                      archive->do_overwrite ? "" : " -k",
+	                      (archive->do_overwrite || archive->do_update) ? "" : " -k",
 	                      archive->do_update ? " --keep-newer-files" : "",
 	                      " -C ", extract_to, files->str, NULL);
 

--- a/src/zip.c
+++ b/src/zip.c
@@ -234,7 +234,7 @@ gboolean xa_zip_extract (XArchive *archive, GSList *file_list)
 	command = g_strconcat(archiver[archive->type].program[0],
 	                      archive->do_full_path ? "" : " -j",
 	                      archive->do_touch ? " -DD" : "",
-	                      archive->do_overwrite ? " -o" : " -n",
+	                      (archive->do_overwrite || archive->do_freshen) ? " -o" : " -n",
 	                      archive->do_update ? " -u" : "",
 	                      archive->do_freshen ? " -f" : "",
 	                      password_str, " ",


### PR DESCRIPTION
When extract tar file with "Update existing files" option or zip file with "Freshen existing files" option checked.
This adds '-k' and '--keep-newer-files' parameters in tar or '-f' and '-n' in unzip.
These excutables doesn't allow to enable both options.