### PR TITLE
Including dirent.h to fix compile errors

### DIFF
--- a/src/open-with-dlg.c
+++ b/src/open-with-dlg.c
@@ -17,6 +17,9 @@
  */
 
 #include <string.h>
+#include <sys/types.h>
+#include <dirent.h>
+
 #include <gtk/gtk.h>
 #include "open-with-dlg.h"
 #include "main.h"

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -18,6 +18,9 @@
 
 #include "config.h"
 #include <string.h>
+#include <sys/types.h>
+#include <dirent.h>
+
 #include "string_utils.h"
 #include "utf8-fnmatch.h"
 


### PR DESCRIPTION
I was unable to compile on Wheezy using the --enable-gtk2 switch without these changes. Does this compile?