### PR TITLE
Change 'extract-here' behaviour

### DIFF
--- a/xarchiver.tap
+++ b/xarchiver.tap
@@ -34,7 +34,7 @@ create)
 	;;
 
 extract-here)
-	exec xarchiver "--extract-to=$folder" "$@"
+	exec xarchiver "--ensure-directory=$folder" "$@"
 	;;
 
 extract-to)


### PR DESCRIPTION
The 'extract-here' action used to directly extract all files contained in the compressed file into the directory containing the compressed file. I believe that most users would expect a subdirectory to be created when a compressed file is extracted, hence the change.