### PR TITLE
Fix several compiler warnings

### DIFF
--- a/src/add_dialog.c
+++ b/src/add_dialog.c
@@ -471,8 +471,7 @@ void xa_execute_add_commands (XArchive *archive, GSList *list, gboolean recurse,
 		list = list->next;
 	}
 	files = xa_collect_filenames(archive, dirlist);
-	g_slist_foreach(dirlist,(GFunc)g_free,NULL);
-	g_slist_free(dirlist);
+	g_slist_free_full(dirlist, g_free);
 
 	archive->status = XARCHIVESTATUS_ADD;
 	(*archive->archiver->add)(archive, files, compression);

--- a/src/archive.c
+++ b/src/archive.c
@@ -411,8 +411,7 @@ void xa_spawn_async_process (XArchive *archive, const gchar *command)
 
 	if (archive->output)
 	{
-		g_slist_foreach(archive->output, (GFunc) g_free, NULL);
-		g_slist_free(archive->output);
+		g_slist_free_full(archive->output, g_free);
 		archive->output = NULL;
 	}
 
@@ -468,11 +467,7 @@ void xa_clean_archive_structure (XArchive *archive)
 	if (archive->comment)
 		g_string_free(archive->comment, TRUE);
 
-	if (archive->output)
-	{
-		g_slist_foreach(archive->output, (GFunc) g_free, NULL);
-		g_slist_free(archive->output);
-	}
+	g_slist_free_full(archive->output, g_free);
 
 	if (archive->clipboard)
 		xa_clipboard_clear(NULL, archive);

--- a/src/extract_dialog.c
+++ b/src/extract_dialog.c
@@ -198,10 +198,11 @@ static void xa_multi_extract_dialog_remove_files (GtkButton *button, Multi_extra
 			gtk_tree_path_free(path);
 		}
 	}
+
 	if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(model),&iter)== FALSE)
 		gtk_widget_set_sensitive(GTK_WIDGET(button), FALSE);
-	g_list_foreach(rr_list,(GFunc)gtk_tree_row_reference_free,NULL);
-	g_list_free(rr_list);
+
+	g_list_free_full(rr_list, (GDestroyNotify) gtk_tree_row_reference_free);
 }
 
 static gchar *xa_multi_extract_one_archive (Multi_extract_data *dialog, gchar *filename, gboolean overwrite, gboolean full_path, gchar *dest_path)

--- a/src/interface.c
+++ b/src/interface.c
@@ -292,11 +292,7 @@ static void xa_dir_sidebar_drag_data_received (GtkWidget *widget, GdkDragContext
 	archive[idx]->do_full_path = full_path;
 
 	g_string_free(full_pathname,TRUE);
-	if (list != NULL)
-	{
-		g_slist_foreach(list,(GFunc) g_free,NULL);
-		g_slist_free(list);
-	}
+	g_slist_free_full(list, g_free);
 	g_strfreev (array);
 	gtk_drag_finish (context,TRUE,FALSE,time);
 }

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -359,8 +359,7 @@ GString *xa_quote_filenames (GSList *file_list, const gchar *escape, gboolean sl
 		list = list->next;
 	}
 
-	g_slist_foreach(file_list, (GFunc) g_free, NULL);
-	g_slist_free(file_list);
+	g_slist_free_full(file_list, g_free);
 
 	return files;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -2127,8 +2127,7 @@ void drag_begin (GtkWidget *widget, GdkDragContext *context, XArchive *archive)
 					(guchar *) XDS_FILENAME,
 			     	strlen (XDS_FILENAME));
 
-	g_list_foreach (row_list,(GFunc) gtk_tree_path_free,NULL);
-	g_list_free (row_list);
+	g_list_free_full(row_list, (GDestroyNotify) gtk_tree_path_free);
 }
 
 void drag_data_get (GtkWidget *widget, GdkDragContext *context, GtkSelectionData *data, guint info, guint time, XArchive *archive)
@@ -2149,8 +2148,7 @@ void drag_data_get (GtkWidget *widget, GdkDragContext *context, GtkSelectionData
 	if (row_list == NULL)
 		return;
 
-	g_list_foreach(row_list, (GFunc) gtk_tree_path_free, NULL);
-	g_list_free(row_list);
+	g_list_free_full(row_list, (GDestroyNotify) gtk_tree_path_free);
 
 	gdk_property_get(gdk_drag_context_get_source_window(context),
 	                 gdk_atom_intern("XdndDirectSave0", FALSE),
@@ -2645,8 +2643,7 @@ void xa_clipboard_clear (GtkClipboard *clipboard, XArchive *archive)
 	{
 		if (archive->clipboard->files != NULL)
 		{
-			g_slist_foreach(archive->clipboard->files, (GFunc) g_free, NULL);
-			g_slist_free(archive->clipboard->files);
+			g_slist_free_full(archive->clipboard->files, g_free);
 			archive->clipboard->files = NULL;
 		}
 
@@ -2738,8 +2735,7 @@ void xa_open_with_from_popupmenu (GtkMenuItem *item, gpointer user_data)
 	while (list_of_files);
 	xa_create_open_with_dialog(entry->filename,names->str,nr);
 	g_string_free(names, FALSE);
-	g_slist_foreach(list_of_files,(GFunc)g_free,NULL);
-	g_slist_free(list_of_files);
+	g_slist_free_full(list_of_files, g_free);
 }
 
 void xa_view_from_popupmenu (GtkMenuItem *item, gpointer user_data)


### PR DESCRIPTION
Recent versions of GCC show warnings like these:

```
string_utils.c: In function 'xa_quote_filenames':
string_utils.c:362:29: warning: cast between incompatible function types
from 'void (*)(void *)' to 'void (*)(void *, void *)'
[-Wcast-function-type]
  g_slist_foreach(file_list, (GFunc) g_free, NULL);
```
Fix this by using "g_[s]list_free_full()" which frees the
list and its entries but does not produce these warnings.