### PR TITLE
Fix 'extract-here' behavior

### DIFF
--- a/xarchiver.tap
+++ b/xarchiver.tap
@@ -34,7 +34,7 @@ create)
 	;;
 
 extract-here)
-	exec xarchiver "--extract-to=$folder" "$@"
+	exec xarchiver --ensure-directory "--extract-to=$folder" "$@"
 	;;
 
 extract-to)


### PR DESCRIPTION
Extract here does not behave the way a user would expect it to. This changes it so that it behaves the same way as other unarchivers, such as 7zip.