### PR TITLE
Replace xa_slist_copy with g_slist_copy_deep

### DIFF
--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -279,19 +279,6 @@ GSList *xa_collect_filenames (XArchive *archive, GSList *in)
 	return out;
 }
 
-GSList *xa_slist_copy(GSList *list)
-{
-	GSList *x,*y = NULL;
-	x = list;
-
-	while (x)
-	{
-		y = g_slist_prepend(y,g_strdup(x->data));
-		x = x->next;
-	}
-	return g_slist_reverse(y);
-}
-
 void xa_recurse_local_directory (gchar *path, GSList **list, gboolean full_path, gboolean recurse)
 {
 	DIR *dir;

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -49,6 +49,5 @@ void xa_recurse_local_directory(gchar *, GSList **, gboolean, gboolean);
 gchar *xa_remove_level_from_path(const gchar *);
 gchar *xa_set_max_width_chars_ellipsize(const gchar *, gint, PangoEllipsizeMode);
 void xa_set_window_title(GtkWidget *, gchar *);
-GSList *xa_slist_copy(GSList *);
 
 #endif


### PR DESCRIPTION
`xa_copy_list_data` is simple wrapper for `g_strdup` to avoid GCC's `-Wcast-function-type` warnings.