### PR TITLE
Add support for 7-Zip 7zz(1)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,20 +103,25 @@ static void xa_check_available_archivers ()
 
 	/* (un)compressors that can handle various types */
 
-	sevenz = g_find_program_in_path("7z");
+	sevenz = g_find_program_in_path("7zz");
 
 	if (!sevenz)
 	{
-		is7z = FALSE;
-		sevenz = g_find_program_in_path("7za");
+		sevenz = g_find_program_in_path("7z");
 
 		if (!sevenz)
 		{
-			is7za = FALSE;
-			sevenz = g_find_program_in_path("7zr");
+			is7z = FALSE;
+			sevenz = g_find_program_in_path("7za");
 
 			if (!sevenz)
-				is7zr = FALSE;
+			{
+				is7za = FALSE;
+				sevenz = g_find_program_in_path("7zr");
+
+				if (!sevenz)
+					is7zr = FALSE;
+			}
 		}
 	}
 


### PR DESCRIPTION
Since [7-Zip 21.01 alpha], 7-Zip has provided a command line version of 7-Zip for Linux with the name 7zz.  The command-line interface is compatible with 7z for all of xarchiver's current uses (as far as I can tell from source inspection and testing basic functionality).

This PR adds a check for `7zz` and uses it when available.

Thanks for considering,
Kevin

[7-Zip 21.01 alpha]: https://sourceforge.net/p/sevenzip/discussion/45797/thread/d401ab2966/