### PR TITLE
Don't make empty 'NEWS' or 'AUTHORS' files

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,8 +2,6 @@
 
 test "$BASH" && set -o pipefail
 
-echo > AUTHORS
-echo > NEWS
 mkdir m4
 
 echo -n "Creating the build system... "
@@ -19,6 +17,6 @@ echo "done."
 
 # clean up in order to keep repository small
 # (will be needed if 'make dist' is used though)
-rm AUTHORS NEWS INSTALL aclocal.m4 intltool-extract.in intltool-merge.in intltool-update.in
+rm INSTALL aclocal.m4 intltool-extract.in intltool-merge.in intltool-update.in
 rm -f config.h.in~ configure~
 rm -r autom4te.cache m4

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_CANONICAL_HOST
 dnl ***************************
 dnl *** Initialize automake ***
 dnl ***************************
-AM_INIT_AUTOMAKE([1.13 dist-xz])
+AM_INIT_AUTOMAKE([1.13 dist-xz foreign])
 AM_PROG_CC_C_O
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE


### PR DESCRIPTION
No longer necessary if you add `foreign` to `AM_INIT_AUTOMAKE`.