### PR TITLE
Fixes 158 - optimize directory lookups via hashmap

### DIFF
--- a/src/archive.h
+++ b/src/archive.h
@@ -158,6 +158,7 @@ struct _XArchive
 	/* data */
 	XEntry *root_entry;
 	XEntry *current_entry;
+	GHashTable *entry_table;
 	/* user interface */
 	GtkWidget *page;
 	GtkWidget *treeview;


### PR DESCRIPTION
Fixes issue 158

added hash table (`entry_table`) to the `XArchive` structure to optimize directory lookups, reducing time for large archives.