### PR TITLE
lha: Recognize `-lhx-` compression algorithm

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -1824,7 +1824,7 @@ ArchiveType xa_detect_archive_type (const gchar *filename)
 	else if (memcmp(magic, "\x1f\x8b", 2) == 0 ||
 	         memcmp(magic, "\x1f\x9e", 2) == 0)
 		xa.type = XARCHIVETYPE_GZIP;
-	else if ((memcmp(magic + 2, "-lh", 3) == 0 && ((magic[5] >= '0' && magic[5] <= '7') || magic[5] == 'd') && magic[6] == '-') ||
+	else if ((memcmp(magic + 2, "-lh", 3) == 0 && ((magic[5] >= '0' && magic[5] <= '7') || magic[5] == 'd' || magic[5] == 'x') && magic[6] == '-') ||
 	         (memcmp(magic + 2, "-lz", 3) == 0 && (magic[5] == '4' || magic[5] == '5' || magic[5] == 's') && magic[6] == '-'))
 		xa.type = XARCHIVETYPE_LHA;
 	else if (memcmp(magic, "LRZI", 4) == 0)


### PR DESCRIPTION
`-lhx-` is an extension of the `-lh7-` algorithm that can be generated by `unlha32.dll` (and can be decompressed by Lhasa). Example archives can be found in the Lhasa test suite:

<https://github.com/fragglet/lhasa/tree/master/test/archives/unlha32>

This change by itself is not sufficient to make xarchiver support these archives; the parsing fixes in #214 are also required.